### PR TITLE
Add texlive-xetex dependency as it is required to use the Pandoc XeLaTeX PDF engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ pacpl \
 pandoc \
 texlive \
 texlive-luatex \
+texlive-xetex \
 texlive-latex-recommended \
 texlive-latex-extra \
 texlive-font-utils \


### PR DESCRIPTION
This pull request is to add the texlive-xetex dependency given that is is required when Docassemble is configured to use XeLaTeX as the PDF engine for Pandoc.