### PR TITLE
Update node to 18.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,12 @@ automake \
 libjpeg-dev \
 libpq-dev \
 logrotate \
-nodejs \
 npm \
 cron \
 libxml2 \
 libxslt1.1 \
+libu2f-udev \
+libvulkan1 \
 libxml2-dev \
 libxslt1-dev \
 libcurl4-openssl-dev \
@@ -126,6 +127,11 @@ libffi-dev \
 uuid-dev \
 && apt-get -y remove libreoffice-report-builder \
 && apt-get -q -y install ttf-mscorefonts-installer \
+&& apt-get -q -y remove nodejs \
+&& apt-get -q -y remove nodejs-doc \
+&& apt-get -q -y autoremove \
+&& curl -fsSL https://deb.nodesource.com/setup_18.x | bash \
+&& apt-get install -y nodejs \
 && apt-get -y autoremove
 RUN DEBIAN_FRONTEND=noninteractive \
 bash -c \


### PR DESCRIPTION
The default node installed on docassemble is v12.22.9. Node 12 reached end of life in April of 2022, and hasn't been getting any updates since. This PR updates to Node 18, which is the current maintenance mode Node version, and has an end of life in 2025.

Specifically making this request to support some of the additional node development that we've been doing more of on docassemble, including [ALKilnInThePlayground](https://github.com/SuffolkLITLab/docassemble-ALKilnInThePlayground), and [compiling bootstrap themes](https://github.com/SuffolkLITLab/docassemble-ALDashboard/pull/74).

I ran this on docassemble and made sure that the one existing use of node on docassemble (the [mmdc](https://docassemble.org/docs/functions.html#mmdc) function) still worked.

The instructions for installing newer node are at https://github.com/nodesource/distributions, and I got some additional help setting it up from
https://askubuntu.com/questions/720784/how-to-install-latest-node-inside-a-docker-container.