### PR TITLE
Added newer version of pdftk-java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,10 @@ uuid-dev \
 && curl -fsSL https://deb.nodesource.com/setup_18.x | bash \
 && apt-get install -y nodejs \
 && apt-get -y autoremove \
+# These lines for pdftk-java can be removed once on 22.10 or higher
+&& curl http://ftp.us.debian.org/debian/pool/main/p/pdftk-java/pdftk-java_3.3.3-1_all.deb --output pdftk-java.deb \
+&& dpkg -i pdftk-java.deb \
+&& rm pdftk-java.deb \
 && npm install -g @mermaid-js/mermaid-cli
 RUN DEBIAN_FRONTEND=noninteractive \
 bash -c \


### PR DESCRIPTION
Resolves https://github.com/jhpyle/docassemble/issues/684 by installing the latest version of `pdftk-java`, which fixes several bugs with reading PDFs.

Went for the simpler version of just downloading the `*.deb` file from the US mirror.

Pros:
* simple; just curl and dpkg
* the [alternate approach](https://gitlab.com/pdftk-java/pdftk/-/issues/136#note_1070556777) is pinning, which I couldn't get working due to `libc-bin` version issues (needed 2.36, but 22.04 only has 2.35)

Cons:
* folks from other countries will have a slower build due to the US mirror being hardcoded. Probably not a huge issue, I don't think many people are building `docassemble-os` from scratch.